### PR TITLE
fix: Implement timezone-aware datetime handling in assays and params

### DIFF
--- a/snailz/params.py
+++ b/snailz/params.py
@@ -2,19 +2,19 @@
 
 from argparse import Namespace
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from importlib.resources import files
 import json
 from pathlib import Path
 from typing import List
-
+import pytz
 
 # Use ISO date format.
 DATE_FORMAT = '%Y-%m-%d'
 
 # Start and end dates for experiemnts.
-DEFAULT_START_DATE = datetime.strptime('2023-11-01', DATE_FORMAT)
-DEFAULT_END_DATE = datetime.strptime('2023-11-10', DATE_FORMAT)
+DEFAULT_START_DATE = datetime.strptime('2023-11-01', DATE_FORMAT).replace(tzinfo=pytz.UTC)
+DEFAULT_END_DATE = datetime.strptime('2023-11-10', DATE_FORMAT).replace(tzinfo=pytz.UTC)
 
 # Parameter files to include in package.
 PARAMETER_FILES = (
@@ -38,13 +38,13 @@ class AssayParams:
     assay_plates: list
     control_val: float = 5.0
     controls: List[str] = field(default_factory=list)
-    enddate: date = None
+    enddate: str = None
     experiments: int = 1
     filename_length: int = 8
     fraction: float = None
     invalid: float = 0.1
     seed: int = None
-    startdate: date = None
+    startdate: str = None
     stdev: float = 3.0
     treated_val: float = 8.0
     treatment: str = None
@@ -53,13 +53,17 @@ class AssayParams:
         '''Fill in missing dates and convert to standard format.'''
         if self.startdate is None:
             self.startdate = DEFAULT_START_DATE
-        else:
-            self.startdate = datetime.strptime(self.startdate, DATE_FORMAT)
+        elif isinstance(self.startdate, str):
+            self.startdate = datetime.strptime(self.startdate, DATE_FORMAT).replace(tzinfo=pytz.UTC)
+        elif not self.startdate.tzinfo:
+            self.startdate = self.startdate.replace(tzinfo=pytz.UTC)
 
         if self.enddate is None:
             self.enddate = DEFAULT_END_DATE
-        else:
-            self.enddate = datetime.strptime(self.enddate, DATE_FORMAT)
+        elif isinstance(self.enddate, str):
+            self.enddate = datetime.strptime(self.enddate, DATE_FORMAT).replace(tzinfo=pytz.UTC)
+        elif not self.enddate.tzinfo:
+            self.enddate = self.enddate.replace(tzinfo=pytz.UTC)
 
 
 @dataclass


### PR DESCRIPTION
It has been quickly implemented as a proof of concept for use in wp4ds. Please double-check that it is correct.
I tested it by replacing `snailz` with `git+https://github.com/juananpe/snailz.git@timezone` in requirements.txt, 
and updating the dependency with `uv pip install -U -r requirements.txt`.
It seems that the test in wp4ds now works correctly.

```
$ make test-timezones
TZ=UTC make datasets
snailz params --outdir params
snailz everything --paramsdir params --datadir data
cp data/assays.json docs/data/assays-utc.json
TZ=America/New_York make datasets
snailz params --outdir params
snailz everything --paramsdir params --datadir data
cp data/assays.json docs/data/assays-ny.json
TZ=Europe/Berlin make datasets
snailz params --outdir params
snailz everything --paramsdir params --datadir data
cp data/assays.json docs/data/assays-berlin.json
TZ=Asia/Tokyo make datasets
snailz params --outdir params
snailz everything --paramsdir params --datadir data
cp data/assays.json docs/data/assays-tokyo.json
TZ=Pacific/Samoa
cp data/assays.json docs/data/assays-samoa.json

$ md5 docs/data/assays-*
MD5 (docs/data/assays-berlin.json) = 582e7363776b746a0b6185bf5630cb0e
MD5 (docs/data/assays-ny.json) = 582e7363776b746a0b6185bf5630cb0e
MD5 (docs/data/assays-samoa.json) = 582e7363776b746a0b6185bf5630cb0e
MD5 (docs/data/assays-tokyo.json) = 582e7363776b746a0b6185bf5630cb0e
MD5 (docs/data/assays-utc.json) = 582e7363776b746a0b6185bf5630cb0e

$ head -20 docs/data/assays-berlin.json
{
    "experiment": [
        {
            "sample_id": 1,
            "kind": "ELISA",
            "start": "2023-11-07",
            "end": "2023-11-07"
        },
        {
            "sample_id": 3,
            "kind": "ELISA",
            "start": "2023-11-02",
            "end": "2023-11-03"
        },
        {
            "sample_id": 4,
            "kind": "JESS",
            "start": "2023-11-02",
            "end": "2023-11-04"
        },
```